### PR TITLE
Added missing 'public' access level

### DIFF
--- a/Koyomi/Koyomi.swift
+++ b/Koyomi/Koyomi.swift
@@ -181,19 +181,19 @@ final public class Koyomi: UICollectionView {
     @IBInspectable public var isHiddenOtherMonth: Bool = false
     
     // Layout properties
-    @IBInspectable var sectionSpace: CGFloat = 1.5 {
+    @IBInspectable public var sectionSpace: CGFloat = 1.5 {
         didSet {
             sectionSeparator.frame.size.height = sectionSpace
         }
     }
-    @IBInspectable var cellSpace: CGFloat = 0.5 {
+    @IBInspectable public var cellSpace: CGFloat = 0.5 {
         didSet {
             if let layout = collectionViewLayout as? KoyomiLayout, layout.cellSpace != cellSpace {
                 setCollectionViewLayout(self.layout, animated: false)
             }
         }
     }
-    @IBInspectable var weekCellHeight: CGFloat = 25 {
+    @IBInspectable public var weekCellHeight: CGFloat = 25 {
         didSet {
             sectionSeparator.frame.origin.y = inset.top + weekCellHeight
             if let layout = collectionViewLayout as? KoyomiLayout, layout.weekCellHeight != weekCellHeight {


### PR DESCRIPTION
Although these properties were marked `@IBInspectable` they lacked the `public` keyword, meaning they defaulted to `internal`. 

```swift
koyomi.cellSpace = 1 // 'cellSpace' is inaccessible due to 'internal' protection level
koyomi.sectionSpace = 1 // 'sectionSpace' is inaccessible due to 'internal' protection level
koyomi.weekCellHeight = 25 // 'weekCellHeight' is inaccessible due to 'internal' protection level
```

As a result these properties could be set with interface builder. But *only* with interface builder.